### PR TITLE
workflows: allow overriding build architectures

### DIFF
--- a/action-test/action.yaml
+++ b/action-test/action.yaml
@@ -2,6 +2,13 @@ name: 'TestSystemSnap'
 description: 'Build and test a system snap'
 author: 'Alfonso Sanchez-Beato'
 
+inputs:
+  architectures:
+    description: Comma separated list of architectures to override the default
+    required: false
+    type: string
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -20,6 +27,8 @@ runs:
         path: cicd
     - name: Build snap
       shell: bash
+      env:
+        BUILD_ARCHITECTURES: ${{ inputs.architectures }}
       run: |
         # We are inside of the checked out repo
         ./cicd/workflows/snap-build.sh "${{ runner.temp }}"

--- a/workflows/common.sh
+++ b/workflows/common.sh
@@ -98,6 +98,7 @@
 # $3: release branch
 # $4: ubuntu series
 # $5: results folder
+# $6: architectures to build for (if empty then default for a given series will be used)
 build_and_download_snaps()
 {
     local snap_n=$1
@@ -105,14 +106,20 @@ build_and_download_snaps()
     local release_br=$3
     local series=$4
     local results_d=$5
+    local build_architectures=${6-}
 
     # Starting with core20/focal, i386 is not supported
-    if [ "$series" = xenial ] || [ "$series" = bionic ]; then
-        archs=i386,amd64,armhf,arm64
-    elif [ "$series" = focal ]; then
-        archs=amd64,armhf,arm64
+    if [ -z "$build_architectures" ]; then
+        if [ "$series" = xenial ] || [ "$series" = bionic ]; then
+            archs=i386,amd64,armhf,arm64
+        elif [ "$series" = focal ]; then
+            archs=amd64,armhf,arm64
+        else
+            archs=amd64,armhf,arm64,riscv64
+        fi
     else
-        archs=amd64,armhf,arm64,riscv64
+        echo "Overriding build architectures to $build_architectures" >&2
+        archs="$build_architectures"
     fi
 
     # Build snap without publishing it to get the new manifest.

--- a/workflows/snap-build.sh
+++ b/workflows/snap-build.sh
@@ -53,12 +53,16 @@ main()
 
     build_and_download_snaps "$snap_name" \
                              https://github.com/"$REPOSITORY".git \
-                             "$BRANCH" "$series" "$build_d"
+                             "$BRANCH" "$series" "$build_d" \
+                             "${BUILD_ARCHITECTURES-}"
 }
 
-if [ $# -ne 1 ]; then
+if [ $# -ne 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     printf "Wrong number of arguments.\n"
     printf "Usage: %s <build_dir>\n" "$0"
+    printf "Environment\n"
+    printf "   - BUILD_ARCHITECTURES - override build architectures\n"
+    printf "\n"
     exit 1
 fi
 main "$1"


### PR DESCRIPTION
Add a way for overriding build architectures. This can be done now by adding:
```
      - name: Build and test
        env:
          LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
        uses: snapcore/system-snaps-cicd-tools/action-test@main
        with:
          architectures: arm64,amd64,armhf
```