### PR TITLE
build-image.sh: make systemd less verbose

### DIFF
--- a/lib/build-image.sh
+++ b/lib/build-image.sh
@@ -118,7 +118,7 @@ EOF
 esac
 
 cat >>"${TMPDIR}/pc/cmdline.extra" <<EOF
-systemd.log_level=debug systemd.journald.forward_to_console=1 console=ttyS0
+systemd.journald.forward_to_console=1 console=ttyS0
 EOF
 
 tar zcf "${TMPDIR}/pc/data.tar.gz" -C "${PROJECT_PATH}" .


### PR DESCRIPTION
This seems to cause issues in booting time, and also gcloud does not keep infinite amount of serial logs.