### PR TITLE
actions*: update to upload-artifactv4

### DIFF
--- a/action-publish-edge/action.yaml
+++ b/action-publish-edge/action.yaml
@@ -60,7 +60,7 @@ runs:
         done
         echo "SNAP_NAME=$SNAP_NAME" >> $GITHUB_ENV
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.SNAP_NAME }}-snaps
         path: ${{ runner.temp }}/${{ env.SNAP_NAME }}_*.snap

--- a/action-release/action.yaml
+++ b/action-release/action.yaml
@@ -55,7 +55,7 @@ runs:
         done
         echo "SNAP_NAME=$SNAP_NAME" >> $GITHUB_ENV
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.SNAP_NAME }}-snaps
         path: ${{ runner.temp }}/${{ env.SNAP_NAME }}_*.snap

--- a/action-test/action.yaml
+++ b/action-test/action.yaml
@@ -55,7 +55,7 @@ runs:
         done
         echo "SNAP_NAME=$SNAP_NAME" >> $GITHUB_ENV
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.SNAP_NAME }}-snaps
         path: ${{ runner.temp }}/${{ env.SNAP_NAME }}_*.snap


### PR DESCRIPTION
Actions using this has now started failing because v3 is deprecated

```
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

**Breaking Changes**

On self hosted runners, additional [firewall rules](https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes) may be required.

Uploading to the same named Artifact multiple times.

Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

Limit of Artifacts for an individual job. Each job in a workflow run now has a limit of 500 artifacts.

With v4.4 and later, hidden files are excluded by default.