### PR TITLE
action:test/publish-edge/release: spread-plus is now called spread

### DIFF
--- a/action-publish-edge/action.yaml
+++ b/action-publish-edge/action.yaml
@@ -72,7 +72,7 @@ runs:
         printf "Running spread tests\n"
         wget -q https://storage.googleapis.com/snapd-spread-tests/spread/spread-plus-amd64.tar.gz \
             -O - | tar xz
-        mv spread-plus ~/bin/spread
+        mv spread ~/bin/spread
         export PATH=$PATH:~/bin/
         # TODO tests for other archs?
         cp "${{ runner.temp }}"/${{ env.SNAP_NAME }}_*_amd64.snap .

--- a/action-release/action.yaml
+++ b/action-release/action.yaml
@@ -48,7 +48,7 @@ runs:
         mv yq_linux_amd64 ~/bin/yq
         wget -q https://storage.googleapis.com/snapd-spread-tests/spread/spread-plus-amd64.tar.gz \
             -O - | tar xz
-        mv spread-plus ~/bin/spread
+        mv spread ~/bin/spread
         export PATH=$PATH:~/bin/
         ./cicd/workflows/snap-release.sh "${{ github.ref_name }}" "${{ runner.temp }}"
         for s in "${{ runner.temp }}"/*_*.snap; do

--- a/action-test/action.yaml
+++ b/action-test/action.yaml
@@ -67,7 +67,7 @@ runs:
         printf "Running spread tests\n"
         wget -q https://storage.googleapis.com/snapd-spread-tests/spread/spread-plus-amd64.tar.gz \
             -O - | tar xz
-        mv spread-plus ~/bin/spread
+        mv spread ~/bin/spread
         export PATH=$PATH:~/bin/
         # TODO tests for other archs?
         cp "${{ runner.temp }}"/${{ env.SNAP_NAME }}_*_amd64.snap .


### PR DESCRIPTION
Tests are failing due to:
`mv: cannot stat 'spread-plus': No such file or directory`

The content of the downloaded `spread-plus-amd64.tar.gz` is now just a single "spread" binary.