### PR TITLE
action:test/publish-edge/release: create ~/bin/ directory before moving the spread binary

### DIFF
--- a/action-publish-edge/action.yaml
+++ b/action-publish-edge/action.yaml
@@ -70,6 +70,7 @@ runs:
       shell: bash
       run: |
         printf "Running spread tests\n"
+        mkdir -p ~/bin
         wget -q https://storage.googleapis.com/snapd-spread-tests/spread/spread-plus-amd64.tar.gz \
             -O - | tar xz
         mv spread ~/bin/spread

--- a/action-test/action.yaml
+++ b/action-test/action.yaml
@@ -65,6 +65,7 @@ runs:
       shell: bash
       run: |
         printf "Running spread tests\n"
+        mkdir -p ~/bin
         wget -q https://storage.googleapis.com/snapd-spread-tests/spread/spread-plus-amd64.tar.gz \
             -O - | tar xz
         mv spread ~/bin/spread


### PR DESCRIPTION
action:test/publish-edge/release: create ~/bin/ directory before moving the spread binary

Test are failing due to
```
Running spread tests
mv: cannot move 'spread' to '/home/ubuntu/bin/spread': No such file or directory
Error: Process completed with exit code 1.
```

See: https://github.com/canonical/network-manager-snap/pull/56