### PR TITLE
action-rebuild-base: add fips build support

### DIFF
--- a/action-rebuild-base/action.yaml
+++ b/action-rebuild-base/action.yaml
@@ -65,7 +65,7 @@ runs:
           IS_FIPS="--fips"
         fi
 
-        ./cicd/workflows/build-base-on-changes.py --output-dir="${{ runner.temp }}" --debug "$series" "$IS_FIPS"
+        ./cicd/workflows/build-base-on-changes.py --output-dir="${{ runner.temp }}" --debug "$series" $IS_FIPS
 
         # TODO run spread tests on built snaps before publishing
 

--- a/action-rebuild-base/action.yaml
+++ b/action-rebuild-base/action.yaml
@@ -18,6 +18,11 @@ inputs:
     required: false
     type: string
     default: "${{ github.ref_name }}"
+  fips:
+    description: Whether this is a FIPS build variant
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -55,7 +60,12 @@ runs:
             series=${snap_name#core}
         fi
 
-        ./cicd/workflows/build-base-on-changes.py --output-dir="${{ runner.temp }}" --debug "$series"
+        IS_FIPS=""
+        if [ "${{ inputs.fips }}" -eq "true" ]; then
+          IS_FIPS="--fips"
+        fi
+
+        ./cicd/workflows/build-base-on-changes.py --output-dir="${{ runner.temp }}" --debug "$series" "$IS_FIPS"
 
         # TODO run spread tests on built snaps before publishing
 


### PR DESCRIPTION
Add a switch to allow for FIPS specific builds, which switches which URLs are used for the recipes and adds the FIPS ppa.