### PR TITLE
action-rebuild-base: the fips input must be evaluated as a bool

### DIFF
--- a/action-rebuild-base/action.yaml
+++ b/action-rebuild-base/action.yaml
@@ -61,7 +61,7 @@ runs:
         fi
 
         IS_FIPS=""
-        if [ "${{ inputs.fips }}" -eq "true" ]; then
+        if [ "${{ inputs.fips }}" = true ]; then
           IS_FIPS="--fips"
         fi
 


### PR DESCRIPTION
It was evaulated as a string - according to the docs they gave the impression this would be the case, but from results this turned out to not be the case, and made the FIPS build simply not build :-)