### PR TITLE
workflows: differentiate between bases under cert and those certified

### DIFF
--- a/workflows/build-base-on-changes.py
+++ b/workflows/build-base-on-changes.py
@@ -417,9 +417,9 @@ def main():
         recipe_tmpl = CORE_SNAP_API
     elif args.fips:
         if args.core_series in fips_certified_map:
-            recipe_tmpl = SNAP_FIPS_API
-        else:
             recipe_tmpl = SNAP_FIPS_CERTIFIED_API
+        else:
+            recipe_tmpl = SNAP_FIPS_API
 
     recipe = recipe_tmpl.format(args.core_series)
     print('building snap recipe', recipe)

--- a/workflows/build-base-on-changes.py
+++ b/workflows/build-base-on-changes.py
@@ -52,7 +52,7 @@ def get_fips_url(core_series: str) -> str:
     templ = 'https://private-ppa.launchpadcontent.net/' + \
         'fips-cc-stig/fips-under-certification/ubuntu/dists/{}/' + \
         'main/binary-amd64/Packages.gz'
-    if core_series in fips_certified_map:                
+    if core_series in fips_certified_map:
         templ = 'https://private-ppa.launchpadcontent.net/' + \
             'ubuntu-advantage/pro-fips-updates/ubuntu/dists/{}/' + \
             'main/binary-amd64/Packages.gz'
@@ -420,7 +420,7 @@ def main():
             recipe_tmpl = SNAP_FIPS_API
         else:
             recipe_tmpl = SNAP_FIPS_CERTIFIED_API
-    
+
     recipe = recipe_tmpl.format(args.core_series)
     print('building snap recipe', recipe)
     snap = lp.load(recipe)


### PR DESCRIPTION
The snap recipes exist under different LP teams, as they use different PPAs. This also means that once core24 is certified, we must update the map in this python script as well as move the recipe under ubuntu-advantage.

Prior to this, the core22-fips build reported 404 as the recipe cannot be found.