### PR TITLE
workflows: support downloads from private repos

### DIFF
--- a/workflows/build-base-on-changes.py
+++ b/workflows/build-base-on-changes.py
@@ -362,27 +362,23 @@ def main():
         lp = Launchpad.login_anonymously(
             'core-builder', 'production', version='devel')
     else:
-        #def login_f(creds_f):
-        #    return Launchpad.login_with(
-        #        'core-builder', 'production', version='devel',
-        #        credentials_file=creds_f)
         def login_f(creds_f):
             return Launchpad.login_with(
-                'the-meulengracht', 'production', version='devel')
+                'core-builder', 'production', version='devel',
+                credentials_file=creds_f)
         creds_env = os.environ.get("LP_CREDENTIALS")
-        #if creds_env and creds_env != '':
-        #    _logger.debug("using credentials from LP_CREDENTIALS env var")
-        #    with tempfile.NamedTemporaryFile() as credential_store_path:
-        #        credential_store_path.write(creds_env.encode("utf-8"))
-        #        credential_store_path.flush()
-        #        lp = login_f(credential_store_path.name)
-        #else:
-        #    _logger.debug("no LP_CREDENTIALS environment variable")
-        #    if not os.path.exists(args.lp_credentials):
-        #        print('Credentials not found, no LP_CREDENTIALS var or file')
-        #        sys.exit(1)
-        #    lp = login_f(args.lp_credentials)
-        lp = login_f("")
+        if creds_env and creds_env != '':
+            _logger.debug("using credentials from LP_CREDENTIALS env var")
+            with tempfile.NamedTemporaryFile() as credential_store_path:
+                credential_store_path.write(creds_env.encode("utf-8"))
+                credential_store_path.flush()
+                lp = login_f(credential_store_path.name)
+        else:
+            _logger.debug("no LP_CREDENTIALS environment variable")
+            if not os.path.exists(args.lp_credentials):
+                print('Credentials not found, no LP_CREDENTIALS var or file')
+                sys.exit(1)
+            lp = login_f(args.lp_credentials)
 
     print('Checking core{}'.format(args.core_series))
 

--- a/workflows/build-base-on-changes.py
+++ b/workflows/build-base-on-changes.py
@@ -258,8 +258,11 @@ def download_snaps(lp, builds, output_dir):
             _logger.debug('Downloading snap from {}'.format(url))
             snap_file = url.rsplit('/', 1)[-1]
             snap_path = os.path.join(output_dir, snap_file)
-            urllib.request.urlretrieve(url, snap_path)
-            snap_found = True
+            try:
+                urllib.request.urlretrieve(url, snap_path)
+                snap_found = True
+            except Exception as e:
+                print('ERROR: failed to download {}: {}'.format(url, e))
         if not snap_found:
             print('No snap found after finishing build in {}'.format(url))
             return False

--- a/workflows/se_utils/__init__.py
+++ b/workflows/se_utils/__init__.py
@@ -164,18 +164,20 @@ def download_snap_build(lp_handle, buildUrl, destination):
     try:
         snap_build = lp_handle.load(buildUrl)
         urls = snap_build.getFileUrls()
-        if len(urls):
-            for u in urls:
-                if not u.endswith('.snap'):
-                    continue
-                print("Downloading snap from %s ..." % u)
-                if not os.path.exists(destination):
-                    os.makedirs(destination)
-                path = os.path.join(destination, os.path.basename(u))
-                # reuse credentials from launchpadlib to download the snap
-                contents = lp_handle._browser.get(u.replace("https://launchpad.net/", str(lp_handle._root_uri)))
-                with open(path, "wb") as out_file:
-                    out_file.write(contents)
+        if len(urls) == 0:
+            raise Exception("No files found for snap build: %s" % buildUrl)
+        
+        for u in urls:
+            if not u.endswith('.snap'):
+                continue
+            print("Downloading snap from %s ..." % u)
+            if not os.path.exists(destination):
+                os.makedirs(destination)
+            path = os.path.join(destination, os.path.basename(u))
+            # reuse credentials from launchpadlib to download the snap
+            contents = lp_handle._browser.get(u.replace("https://launchpad.net/", str(lp_handle._root_uri)))
+            with open(path, "wb") as out_file:
+                out_file.write(contents)
     except HTTPError as ex:
         print("Could not retrieve snap for {}"
                 " (was there an LP timeout?): {}".format(buildUrl, ex))

--- a/workflows/se_utils/__init__.py
+++ b/workflows/se_utils/__init__.py
@@ -26,7 +26,6 @@ from lazr.restfulclient.errors import HTTPError
 from launchpadlib.launchpad import Launchpad
 from launchpadlib.credentials import UnencryptedFileCredentialStore
 
-
 class LaunchpadVote():
     APPROVE = 'Approve'
     DISAPPROVE = 'Disapprove'
@@ -153,3 +152,32 @@ def get_branch_handle_from_url(lp_handle, url):
                             'lp://staging/')
         print('fetching branch: ' + name)
         return lp_handle.branches.getByUrl(url=name)
+
+
+def download_snap_build(lp_handle, buildUrl, destination):
+    """ Download a snap build from a url to a destination.
+    If the download fails, do not raise an exception, just return False.
+    :param buildUrl: url of the snap build to download
+    :param destination: path to save the downloaded file
+    :return: True if the download was successful, False otherwise
+    """
+    try:
+        snap_build = lp_handle.load(buildUrl)
+        urls = snap_build.getFileUrls()
+        if len(urls):
+            for u in urls:
+                if not u.endswith('.snap'):
+                    continue
+                print("Downloading snap from %s ..." % u)
+                if not os.path.exists(destination):
+                    os.makedirs(destination)
+                path = os.path.join(destination, os.path.basename(u))
+                # reuse credentials from launchpadlib to download the snap
+                contents = lp_handle._browser.get(u.replace("https://launchpad.net/", str(lp_handle._root_uri)))
+                with open(path, "wb") as out_file:
+                    out_file.write(contents)
+    except HTTPError as ex:
+        print("Could not retrieve snap for {}"
+                " (was there an LP timeout?): {}".format(buildUrl, ex))
+        return False
+    return True

--- a/workflows/trigger-lp-build.py
+++ b/workflows/trigger-lp-build.py
@@ -323,22 +323,13 @@ def main(argv):
                     print("Could not get build summary for {} "
                           "(was there an LP timeout?): {}".format(success, ex))
 
-            try:
-                snap_build = launchpad.load(triggered_build_urls[success])
-                urls = snap_build.getFileUrls()
-                if len(urls):
-                    for u in urls:
-                        print("Downloading snap from %s ..." % u)
-                        response = url_pool.request('GET', u)
-                        if not os.path.exists(results_dir):
-                            os.makedirs(results_dir)
-                        path = os.path.join(results_dir, os.path.basename(u))
-                        with open(path, "wb") as out_file:
-                            out_file.write(response.data)
-            except Exception as ex:
-                print("Could not retrieve snap build data for {}"
-                      "(was there an LP timeout?): {}".format(build, ex))
-                continue
+            # attempt to download the file
+            downloaded = se_utils.download_snap_build(
+                launchpad, triggered_build_urls[success],
+                results_dir)
+            if not downloaded:
+                print("WARNING: Could not download snap build for id: {}".
+                      format(success))
 
     if ephemeral_build:
         snap.lp_delete()


### PR DESCRIPTION
Reuse the _browser object from the launchpad object to fetch builds.