### PR TITLE
workflows,action-rebuild-base: fix package comparison and publishing for FIPS

### DIFF
--- a/action-rebuild-base/action.yaml
+++ b/action-rebuild-base/action.yaml
@@ -91,5 +91,10 @@ runs:
       if: ${{ env.SNAP_NAME != '' }}
       shell: bash
       run: |
+        CHANNEL="latest/edge"
+        if [ "${{ inputs.fips }}" = true ]; then
+          CHANNEL="fips-updates/edge"
+        fi
+
         ./cicd/workflows/snap-publish.sh "${{ runner.temp }}" \
-            ${{ env.SNAP_NAME }} latest/edge
+            ${{ env.SNAP_NAME }} $CHANNEL

--- a/workflows/build-base-on-changes.py
+++ b/workflows/build-base-on-changes.py
@@ -73,14 +73,17 @@ def package_versions_from_file(pkgs_p, snap2version):
             update_snap2version(snap2version, package, version)
 
 
-def check_packages_changed(core_series):
+def check_packages_changed(core_series, fips):
     # Note that we consider here only amd64, at the moment there are no
     # differences in packages primed in bases depending on arches.
     changed = False
     with tempfile.TemporaryDirectory() as base_tmpd:
         # Download edge snap, extract manifest
         base = 'core{}'.format(core_series)
-        subprocess.run(['snap', 'download', '--edge', '--basename', base,
+        channel = 'edge'
+        if fips:
+            channel = 'fips-updates/edge'
+        subprocess.run(['snap', 'download', '--channel=' + channel, '--basename', base,
                         '--target-directory', base_tmpd, base], check=True)
         sq_d = os.path.join(base_tmpd, base)
         base_p = os.path.join(base_tmpd, base + '.snap')
@@ -415,7 +418,7 @@ def main():
     policies = []
     if not args.no_git_check:
         policies.append(lambda: check_branch_changed(branch))
-    policies.append(lambda: check_packages_changed(args.core_series))
+    policies.append(lambda: check_packages_changed(args.core_series, args.fips))
 
     ret = 0
     for policy in policies:

--- a/workflows/build-base-on-changes.py
+++ b/workflows/build-base-on-changes.py
@@ -46,7 +46,8 @@ series_map = {
 
 # The map of bases that are fips certified, they move to ubuntu-advantage.
 fips_certified_map = {
-    "22": "jammy"
+    "22": "jammy",
+    "24": "noble",
 }
 
 

--- a/workflows/build-base-on-changes.py
+++ b/workflows/build-base-on-changes.py
@@ -81,7 +81,7 @@ def check_packages_changed(core_series, fips):
     with tempfile.TemporaryDirectory() as base_tmpd:
         # Download edge snap, extract manifest
         base = 'core{}'.format(core_series)
-        channel = 'edge'
+        channel = 'latest/edge'
         if fips:
             channel = 'fips-updates/edge'
         subprocess.run(['snap', 'download', '--channel=' + channel, '--basename', base,


### PR DESCRIPTION
fix the package comparison by downloading the correct snap version, also fix the publishing of core snaps to the correct channels.