### PR TITLE
Prepare for core26/Resolute

### DIFF
--- a/snapd-lib/external/snapd-testing-tools/tools/os.query
+++ b/snapd-lib/external/snapd-testing-tools/tools/os.query
@@ -2,9 +2,9 @@
 
 show_help() {
     echo "usage: os.query is-core, is-classic"
-    echo "       os.query is-core16, is-core18, is-core20, is-core22, is-core24"
+    echo "       os.query is-core16, is-core18, is-core20, is-core22, is-core24, is-core26"
     echo "       os.query is-core-gt, is-core-ge, is-core-lt, is-core-le"
-    echo "       os.query is-trusty, is-xenial, is-bionic, is-focal, is-jammy, is-noble"
+    echo "       os.query is-trusty, is-xenial, is-bionic, is-focal, is-jammy, is-noble, is-resolute"
     echo "       os.query is-ubuntu [ID], is-debian [ID], is-fedora [ID], is-amazon-linux [ID], is-arch-linux, is-centos [ID], is-opensuse [ID]"
     echo "       os.query is-ubuntu-gt [ID], is-ubuntu-ge [ID], is-ubuntu-lt [ID], is-ubuntu-le [ID]"
     echo "       os.query is-pc-amd64, is-pc-i386, is-arm, is-armhf, is-arm64, is-s390x"
@@ -34,6 +34,10 @@ is_core22() {
 
 is_core24() {
     grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="24"' /etc/os-release
+}
+
+is_core26() {
+    grep -qFx 'ID=ubuntu-core' /etc/os-release && grep -qFx 'VERSION_ID="26"' /etc/os-release
 }
 
 is_core_gt() {
@@ -102,6 +106,10 @@ is_jammy() {
 
 is_noble() {
     grep -qFx 'UBUNTU_CODENAME=noble' /etc/os-release
+}
+
+is_resolute() {
+    grep -qFx 'UBUNTU_CODENAME=resolute' /etc/os-release
 }
 
 is_ubuntu() {

--- a/snapd-lib/image.sh
+++ b/snapd-lib/image.sh
@@ -34,6 +34,12 @@ get_google_image_url_for_vm() {
         ubuntu-24.04-arm-64*)
             echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/noble-server-cloudimg-arm64.img"
             ;;
+        ubuntu-26.04-64*)
+            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/resolute-server-cloudimg-amd64.img"
+            ;;
+        ubuntu-26.04-arm-64*)
+            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/resolute-server-cloudimg-arm64.img"
+            ;;
         *)
             echo "unsupported system"
             exit 1
@@ -70,6 +76,12 @@ get_ubuntu_image_url_for_vm() {
             ;;
         ubuntu-24.04-arm-64*)
             echo "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-arm64.img"
+            ;;
+        ubuntu-26.04-64*)
+            echo "https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-amd64.img"
+            ;;
+        ubuntu-26.04-arm-64*)
+            echo "https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-arm64.img"
             ;;
         *)
             echo "unsupported system"

--- a/snapd-lib/nested.sh
+++ b/snapd-lib/nested.sh
@@ -296,6 +296,10 @@ nested_is_classic_system() {
     test "$NESTED_TYPE" = "classic"
 }
 
+nested_is_core_26_system() {
+    os.query is-resolute
+}
+
 nested_is_core_24_system() {
     os.query is-noble
 }

--- a/workflows/build-base-on-changes.py
+++ b/workflows/build-base-on-changes.py
@@ -42,12 +42,14 @@ series_map = {
     "20": "focal",
     "22": "jammy",
     "24": "noble",
+    "26": "resolute",
 }
 
 # The map of bases that are fips certified, they move to ubuntu-advantage.
 fips_certified_map = {
     "22": "jammy",
     "24": "noble",
+    "26": "resolute",
 }
 
 

--- a/workflows/trigger-lp-build.py
+++ b/workflows/trigger-lp-build.py
@@ -63,7 +63,9 @@ def parseargs(argv):
 
 
 def get_series(base):
-    if base == "core24":
+    if base == "core26":
+        return "resolute"
+    elif base == "core24":
         return "noble"
     elif base == "core22":
         return "jammy"


### PR DESCRIPTION
This PR is in preparation for `core26` based system snap builds, running on Ubuntu Resolute 26.04 LTS.

E.g.: https://github.com/canonical/network-manager-snap/pull/65