### PR TITLE
workflows, action-rebuild-base: upload changelog to github release

### DIFF
--- a/action-rebuild-base/action.yaml
+++ b/action-rebuild-base/action.yaml
@@ -28,6 +28,11 @@ inputs:
     required: false
     type: string
     default: regular
+  upload-changelog:
+    description: Whether to create a GitHub Release and upload the ChangeLog
+    required: false
+    type: boolean
+    default: true
 
 outputs:
   snap_name:
@@ -119,7 +124,7 @@ runs:
         path: ${{ runner.temp }}/${{ steps.release.outputs.snap_name }}_*.snap
     - name: Create GitHub Release and upload ChangeLog
       # Requires the calling workflow to have: permissions: contents: write
-      if: ${{ steps.release.outputs.snap_name != '' && steps.release.outputs.build_tag != '' }}
+      if: ${{ steps.release.outputs.snap_name != '' && steps.release.outputs.build_tag != '' && inputs.upload-changelog }}
       shell: bash
       run: |
         ./cicd/workflows/github-release.sh \

--- a/action-rebuild-base/action.yaml
+++ b/action-rebuild-base/action.yaml
@@ -36,6 +36,9 @@ outputs:
   snap_artifact:
     description: Artifact basename used for uploaded snaps
     value: ${{ steps.release.outputs.snap_artifact }}
+  build_tag:
+    description: Git tag created for this build (empty when no build was triggered)
+    value: ${{ steps.release.outputs.build_tag }}
 
 runs:
   using: "composite"
@@ -99,12 +102,30 @@ runs:
 
         echo "snap_name=$SNAP_NAME" >> "$GITHUB_OUTPUT"
         echo "snap_artifact=$SNAP_ARTIFACT" >> "$GITHUB_OUTPUT"
+
+        # Capture the git tag created by build-base-on-changes.py (if a build
+        # was triggered). The tag follows the pattern YYYYMMDD_<branch>+<variant>
+        # or YYYYMMDD-<seq>_<branch>+<variant> for same-day retries.
+        BUILD_TAG=
+        if [ -n "$SNAP_NAME" ]; then
+            BUILD_TAG=$(git tag --points-at HEAD | grep -E '^[0-9]{8}(-[0-9]+)?_' | head -1 || true)
+        fi
+        echo "build_tag=$BUILD_TAG" >> "$GITHUB_OUTPUT"
     - name: Upload artifacts
       if: ${{ steps.release.outputs.snap_name != '' }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.release.outputs.snap_artifact }}-snaps
         path: ${{ runner.temp }}/${{ steps.release.outputs.snap_name }}_*.snap
+    - name: Create GitHub Release and upload ChangeLog
+      # Requires the calling workflow to have: permissions: contents: write
+      if: ${{ steps.release.outputs.snap_name != '' && steps.release.outputs.build_tag != '' }}
+      shell: bash
+      run: |
+        ./cicd/workflows/github-release.sh \
+            "${{ runner.temp }}" \
+            "${{ steps.release.outputs.snap_name }}" \
+            "${{ steps.release.outputs.build_tag }}"
     - name: Publish the snaps to edge channel
       if: ${{ steps.release.outputs.snap_name != '' && inputs.publish }}
       shell: bash

--- a/workflows/github-release.sh
+++ b/workflows/github-release.sh
@@ -38,92 +38,96 @@ if [ -z "$snap_dir" ] || [ -z "$snap_name" ] || [ -z "$tag" ]; then
     exit 1
 fi
 
-# Find a snap to extract the ChangeLog from.
-# Prefer amd64 for reproducibility; fall back to the first snap found.
-snap_file=
-for f in "$snap_dir"/"${snap_name}"_*_amd64.snap; do
-    if test -f "$f"; then
-        snap_file=$f
-        break
-    fi
-done
-if [ -z "$snap_file" ]; then
-    for f in "$snap_dir"/"${snap_name}"_*.snap; do
-        if test -f "$f"; then
-            snap_file=$f
-            break
-        fi
-    done
-fi
-
-if [ -z "$snap_file" ]; then
-    printf "ERROR: no snap file found in '%s' for snap '%s'\n" \
-           "$snap_dir" "$snap_name" >&2
+mapfile -t snaps < <(find "$snap_dir" -maxdepth 1 -name "${snap_name}_*.snap")
+if [ ${#snaps[@]} -eq 0 ]; then
+    printf "ERROR: no snap files found in '%s' for snap '%s'\n" "$snap_dir" "$snap_name" >&2
     exit 1
 fi
 
-printf "Extracting ChangeLog from %s\n" "$snap_file"
-
-# Extract only the ChangeLog path from the snap into a temporary directory.
+# Extract ChangeLog from every downloaded snap. Each is uploaded as
+# ChangeLog_<arch>. Release notes are always taken from the amd64 snap.
 extract_dir=$(mktemp -d)
 trap 'rm -rf "$extract_dir"' EXIT
 
-unsquashfs -d "$extract_dir/squashfs-root" "$snap_file" usr/share/doc/ChangeLog
+upload_args=()
+changelog_for_notes=""
 
-changelog_file="$extract_dir/squashfs-root/usr/share/doc/ChangeLog"
-if [ ! -f "$changelog_file" ]; then
-    printf "ERROR: ChangeLog not found at usr/share/doc/ChangeLog inside snap\n" >&2
+for snap_p in "${snaps[@]}"; do
+    # Extract arch from snap filename, e.g. core24_20260627_amd64.snap:
+    # strip up to and including the last '_', then strip the '.snap' suffix.
+    arch=${snap_p##*_}
+    arch=${arch%.snap}
+    printf "Extracting ChangeLog from %s\n" "$snap_p"
+    unsquashfs -d "$extract_dir/$arch" "$snap_p" usr/share/doc/ChangeLog
+    cl_file="$extract_dir/$arch/usr/share/doc/ChangeLog"
+    if test -f "$cl_file"; then
+        # The '<path>#<label>' syntax sets the asset display name.
+        upload_args+=("$cl_file#ChangeLog_$arch")
+        if [ "$arch" = amd64 ]; then
+            changelog_for_notes=$cl_file
+        fi
+    else
+        printf "WARNING: ChangeLog not found inside snap %s\n" "$snap_p" >&2
+    fi
+done
+
+if [ ${#upload_args[@]} -eq 0 ]; then
+    printf "ERROR: no ChangeLog found in any snap for '%s'\n" "$snap_name" >&2
     exit 1
 fi
 
-# Parse the latest (first) ChangeLog entry for use as release notes.
-# Entry header format: DD/MM/YYYY, commit https://.../tree/<sha>
 release_notes=""
-entry_header=$(head -1 "$changelog_file")
-entry_date=$(printf '%s' "$entry_header" | grep -oP '^\d{2}/\d{2}/\d{4}') || true
-entry_commit=$(printf '%s' "$entry_header" | grep -oP '/tree/\K[0-9a-f]+$') || true
+if [ -n "$changelog_for_notes" ]; then
+    # Parse the latest (first) ChangeLog entry for use as release notes.
+    # Entry header format: DD/MM/YYYY, commit https://.../tree/<sha>
+    entry_header=$(head -1 "$changelog_for_notes")
+    entry_date=$(printf '%s' "$entry_header" | grep -oP '^\d{2}/\d{2}/\d{4}') || true
+    entry_commit=$(printf '%s' "$entry_header" | grep -oP '/tree/\K[0-9a-f]+$') || true
 
-if [ -z "$entry_date" ] || [ -z "$entry_commit" ]; then
-    printf "WARNING: could not parse ChangeLog entry header: %s\n" "$entry_header" >&2
+    if [ -z "$entry_date" ] || [ -z "$entry_commit" ]; then
+        printf "WARNING: could not parse ChangeLog entry header: %s\n" "$entry_header" >&2
+    else
+        # Derive expected date in DD/MM/YYYY from tag (first 8 chars are YYYYMMDD)
+        tag_ymd=${tag:0:8}
+        expected_date="${tag_ymd:6:2}/${tag_ymd:4:2}/${tag_ymd:0:4}"
+        # Get the commit SHA the tag points to.
+        tag_commit=$(git rev-parse "$tag")
+
+        valid=true
+        if [ "$entry_date" != "$expected_date" ]; then
+            printf "WARNING: ChangeLog date '%s' does not match tag date '%s'\n" \
+                   "$entry_date" "$expected_date" >&2
+            valid=false
+        fi
+        if [ "$entry_commit" != "$tag_commit" ]; then
+            printf "WARNING: ChangeLog commit '%s' does not match tag commit '%s'\n" \
+                   "$entry_commit" "$tag_commit" >&2
+            valid=false
+        fi
+
+        if [ "$valid" = true ]; then
+            # Extract entry: lines from header until next entry header or EOF
+            release_notes=$(printf "ChangeLog for amd64 snap:\n\n";
+                            awk 'NR > 1 && /^[0-9]{2}\/[0-9]{2}\/[0-9]{4}, commit/ { exit } { print }' \
+                                "$changelog_for_notes")
+        fi
+    fi
 else
-    # Derive expected date in DD/MM/YYYY from tag (first 8 chars are YYYYMMDD)
-    tag_ymd=${tag:0:8}
-    expected_date="${tag_ymd:6:2}/${tag_ymd:4:2}/${tag_ymd:0:4}"
-    # Get the commit SHA the tag points to.
-    tag_commit=$(git rev-parse "$tag")
-
-    valid=true
-    if [ "$entry_date" != "$expected_date" ]; then
-        printf "WARNING: ChangeLog date '%s' does not match tag date '%s'\n" \
-               "$entry_date" "$expected_date" >&2
-        valid=false
-    fi
-    if [ "$entry_commit" != "$tag_commit" ]; then
-        printf "WARNING: ChangeLog commit '%s' does not match tag commit '%s'\n" \
-               "$entry_commit" "$tag_commit" >&2
-        valid=false
-    fi
-
-    if [ "$valid" = true ]; then
-        # Extract entry: lines from header until next entry header or EOF
-        release_notes=$(awk \
-            'NR > 1 && /^[0-9]{2}\/[0-9]{2}\/[0-9]{4}, commit/ { exit } { print }' \
-            "$changelog_file")
-    fi
+    printf "WARNING: no amd64 snap found. Release notes will indicate missing ChangeLog\n" >&2
+    release_notes="ChangeLog for amd64 snap not found. See attached per-arch ChangeLogs."
 fi
 
-# Create the GitHub Release and attach the ChangeLog as a release asset.
+# Create the GitHub Release and attach ChangeLog_<arch> files as assets.
 # If a release for this tag already exists (e.g. a retried run), update its
-# notes and overwrite the asset.
-# The '<path>#<label>' syntax sets the asset display name to 'ChangeLog'.
+# notes and overwrite the assets.
 if gh release view "$tag" >& /dev/null; then
-    printf "Release for tag '%s' already exists; updating notes and uploading ChangeLog\n" "$tag"
+    printf "Release for tag '%s' already exists; updating notes and uploading ChangeLogs\n" "$tag"
     gh release edit "$tag" --notes "$release_notes"
-    gh release upload "$tag" "$changelog_file#ChangeLog" --clobber
+    gh release upload "$tag" "${upload_args[@]}" --clobber
 else
     printf "Creating GitHub Release for tag '%s'\n" "$tag"
     gh release create "$tag" \
         --title "$tag" \
         --notes "$release_notes" \
-        "$changelog_file#ChangeLog"
+        "${upload_args[@]}"
 fi

--- a/workflows/github-release.sh
+++ b/workflows/github-release.sh
@@ -76,17 +76,54 @@ if [ ! -f "$changelog_file" ]; then
     exit 1
 fi
 
+# Parse the latest (first) ChangeLog entry for use as release notes.
+# Entry header format: DD/MM/YYYY, commit https://.../tree/<sha>
+release_notes=""
+entry_header=$(head -1 "$changelog_file")
+entry_date=$(printf '%s' "$entry_header" | grep -oP '^\d{2}/\d{2}/\d{4}') || true
+entry_commit=$(printf '%s' "$entry_header" | grep -oP '/tree/\K[0-9a-f]+$') || true
+
+if [ -z "$entry_date" ] || [ -z "$entry_commit" ]; then
+    printf "WARNING: could not parse ChangeLog entry header: %s\n" "$entry_header" >&2
+else
+    # Derive expected date in DD/MM/YYYY from tag (first 8 chars are YYYYMMDD)
+    tag_ymd=${tag:0:8}
+    expected_date="${tag_ymd:6:2}/${tag_ymd:4:2}/${tag_ymd:0:4}"
+    # Get the commit SHA the tag points to.
+    tag_commit=$(git rev-parse "$tag")
+
+    valid=true
+    if [ "$entry_date" != "$expected_date" ]; then
+        printf "WARNING: ChangeLog date '%s' does not match tag date '%s'\n" \
+               "$entry_date" "$expected_date" >&2
+        valid=false
+    fi
+    if [ "$entry_commit" != "$tag_commit" ]; then
+        printf "WARNING: ChangeLog commit '%s' does not match tag commit '%s'\n" \
+               "$entry_commit" "$tag_commit" >&2
+        valid=false
+    fi
+
+    if [ "$valid" = true ]; then
+        # Extract entry: lines from header until next entry header or EOF
+        release_notes=$(awk \
+            'NR > 1 && /^[0-9]{2}\/[0-9]{2}\/[0-9]{4}, commit/ { exit } { print }' \
+            "$changelog_file")
+    fi
+fi
+
 # Create the GitHub Release and attach the ChangeLog as a release asset.
-# If a release for this tag already exists (e.g. a retried run), skip creation
-# and only upload/overwrite the asset.
+# If a release for this tag already exists (e.g. a retried run), update its
+# notes and overwrite the asset.
 # The '<path>#<label>' syntax sets the asset display name to 'ChangeLog'.
 if gh release view "$tag" >& /dev/null; then
-    printf "Release for tag '%s' already exists; uploading ChangeLog only\n" "$tag"
+    printf "Release for tag '%s' already exists; updating notes and uploading ChangeLog\n" "$tag"
+    gh release edit "$tag" --notes "$release_notes"
     gh release upload "$tag" "$changelog_file#ChangeLog" --clobber
 else
     printf "Creating GitHub Release for tag '%s'\n" "$tag"
     gh release create "$tag" \
         --title "$tag" \
-        --notes "" \
+        --notes "$release_notes" \
         "$changelog_file#ChangeLog"
 fi

--- a/workflows/github-release.sh
+++ b/workflows/github-release.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# Copyright (C) 2024 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Creates a GitHub Release for the given tag and uploads the ChangeLog
+# extracted from a downloaded snap file.
+#
+# Usage: github-release.sh <snap_dir> <snap_name> <tag>
+#
+# The gh CLI uses GITHUB_TOKEN, which is automatically available in GitHub
+# Actions. The calling workflow must have: permissions: contents: write
+
+set -eu -o pipefail
+
+if [ $# -ne 3 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    printf "Usage: %s <snap_dir> <snap_name> <tag>\n" "$0"
+    exit 1
+fi
+
+snap_dir=$1
+snap_name=$2
+tag=$3
+
+if [ -z "$snap_dir" ] || [ -z "$snap_name" ] || [ -z "$tag" ]; then
+    printf "ERROR: snap_dir, snap_name, and tag must be non-empty\n" >&2
+    exit 1
+fi
+
+# Find a snap to extract the ChangeLog from.
+# Prefer amd64 for reproducibility; fall back to the first snap found.
+snap_file=
+for f in "$snap_dir"/"${snap_name}"_*_amd64.snap; do
+    if test -f "$f"; then
+        snap_file=$f
+        break
+    fi
+done
+if [ -z "$snap_file" ]; then
+    for f in "$snap_dir"/"${snap_name}"_*.snap; do
+        if test -f "$f"; then
+            snap_file=$f
+            break
+        fi
+    done
+fi
+
+if [ -z "$snap_file" ]; then
+    printf "ERROR: no snap file found in '%s' for snap '%s'\n" \
+           "$snap_dir" "$snap_name" >&2
+    exit 1
+fi
+
+printf "Extracting ChangeLog from %s\n" "$snap_file"
+
+# Extract only the ChangeLog path from the snap into a temporary directory.
+extract_dir=$(mktemp -d)
+trap 'rm -rf "$extract_dir"' EXIT
+
+unsquashfs -d "$extract_dir/squashfs-root" "$snap_file" usr/share/doc/ChangeLog
+
+changelog_file="$extract_dir/squashfs-root/usr/share/doc/ChangeLog"
+if [ ! -f "$changelog_file" ]; then
+    printf "ERROR: ChangeLog not found at usr/share/doc/ChangeLog inside snap\n" >&2
+    exit 1
+fi
+
+# Create the GitHub Release and attach the ChangeLog as a release asset.
+# If a release for this tag already exists (e.g. a retried run), skip creation
+# and only upload/overwrite the asset.
+# The '<path>#<label>' syntax sets the asset display name to 'ChangeLog'.
+if gh release view "$tag" >& /dev/null; then
+    printf "Release for tag '%s' already exists; uploading ChangeLog only\n" "$tag"
+    gh release upload "$tag" "$changelog_file#ChangeLog" --clobber
+else
+    printf "Creating GitHub Release for tag '%s'\n" "$tag"
+    gh release create "$tag" \
+        --title "$tag" \
+        --notes "" \
+        "$changelog_file#ChangeLog"
+fi


### PR DESCRIPTION
[SNAPDENG-37156](https://warthogs.atlassian.net/browse/SNAPDENG-37156)

Unfortunately, it seems I cannot run a test workflow in core-base from a test branch to verify this: https://github.com/canonical/core-base/actions/runs/28407463691/job/84173057068

[SNAPDENG-37127]: https://warthogs.atlassian.net/browse/SNAPDENG-37127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SNAPDENG-37156]: https://warthogs.atlassian.net/browse/SNAPDENG-37156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ